### PR TITLE
Update styles and dependencies.

### DIFF
--- a/less/ebook.less
+++ b/less/ebook.less
@@ -1,94 +1,76 @@
 pre, code {
+    /* From https://github.com/isagalaev/highlight.js/blob/9.8.0/src/styles/tomorrow.css */
+
     /* http://jmblog.github.io/color-themes-for-highlightjs */
 
     /* Tomorrow Comment */
     .hljs-comment,
-    .hljs-title {
+    .hljs-quote {
         color: #8e908c;
     }
 
     /* Tomorrow Red */
     .hljs-variable,
-    .hljs-attribute,
+    .hljs-template-variable,
     .hljs-tag,
+    .hljs-name,
+    .hljs-selector-id,
+    .hljs-selector-class,
     .hljs-regexp,
-    .hljs-deletion,
-    .ruby .hljs-constant,
-    .xml .hljs-tag .hljs-title,
-    .xml .hljs-pi,
-    .xml .hljs-doctype,
-    .html .hljs-doctype,
-    .css .hljs-id,
-    .css .hljs-class,
-    .css .hljs-pseudo {
+    .hljs-deletion {
         color: #c82829;
     }
 
     /* Tomorrow Orange */
     .hljs-number,
-    .hljs-preprocessor,
-    .hljs-pragma,
     .hljs-built_in,
+    .hljs-builtin-name,
     .hljs-literal,
+    .hljs-type,
     .hljs-params,
-    .hljs-constant {
+    .hljs-meta,
+    .hljs-link {
         color: #f5871f;
     }
 
     /* Tomorrow Yellow */
-    .ruby .hljs-class .hljs-title,
-    .css .hljs-rules .hljs-attribute {
+    .hljs-attribute {
         color: #eab700;
     }
 
     /* Tomorrow Green */
     .hljs-string,
-    .hljs-value,
-    .hljs-inheritance,
-    .hljs-header,
-    .hljs-addition,
-    .ruby .hljs-symbol,
-    .xml .hljs-cdata {
+    .hljs-symbol,
+    .hljs-bullet,
+    .hljs-addition {
         color: #718c00;
     }
 
-    /* Tomorrow Aqua */
-    .css .hljs-hexcolor {
-        color: #3e999f;
-    }
-
     /* Tomorrow Blue */
-    .hljs-function,
-    .python .hljs-decorator,
-    .python .hljs-title,
-    .ruby .hljs-function .hljs-title,
-    .ruby .hljs-title .hljs-keyword,
-    .perl .hljs-sub,
-    .javascript .hljs-title,
-    .coffeescript .hljs-title {
+    .hljs-title,
+    .hljs-section {
         color: #4271ae;
     }
 
     /* Tomorrow Purple */
     .hljs-keyword,
-    .javascript .hljs-function {
+    .hljs-selector-tag {
         color: #8959a8;
     }
 
     .hljs {
         display: block;
+        overflow-x: auto;
         background: white;
         color: #4d4d4c;
         padding: 0.5em;
     }
 
-    .coffeescript .javascript,
-    .javascript .xml,
-    .tex .hljs-formula,
-    .xml .javascript,
-    .xml .vbscript,
-    .xml .css,
-    .xml .hljs-cdata {
-        opacity: 0.5;
+    .hljs-emphasis {
+        font-style: italic;
+    }
+
+    .hljs-strong {
+        font-weight: bold;
     }
 }

--- a/less/night.less
+++ b/less/night.less
@@ -1,94 +1,76 @@
+/* From https://github.com/isagalaev/highlight.js/blob/9.8.0/src/styles/tomorrow-night-bright.css */
+
 /* Tomorrow Night Bright Theme */
 /* Original theme - https://github.com/chriskempson/tomorrow-theme */
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
 /* Tomorrow Comment */
 .hljs-comment,
-.hljs-title {
+.hljs-quote {
   color: #969896;
 }
 
 /* Tomorrow Red */
 .hljs-variable,
-.hljs-attribute,
+.hljs-template-variable,
 .hljs-tag,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class,
 .hljs-regexp,
-.hljs-deletion,
-.ruby .hljs-constant,
-.xml .hljs-tag .hljs-title,
-.xml .hljs-pi,
-.xml .hljs-doctype,
-.html .hljs-doctype,
-.css .hljs-id,
-.css .hljs-class,
-.css .hljs-pseudo {
+.hljs-deletion {
   color: #d54e53;
 }
 
 /* Tomorrow Orange */
 .hljs-number,
-.hljs-preprocessor,
-.hljs-pragma,
 .hljs-built_in,
+.hljs-builtin-name,
 .hljs-literal,
+.hljs-type,
 .hljs-params,
-.hljs-constant {
+.hljs-meta,
+.hljs-link {
   color: #e78c45;
 }
 
 /* Tomorrow Yellow */
-.ruby .hljs-class .hljs-title,
-.css .hljs-rules .hljs-attribute {
+.hljs-attribute {
   color: #e7c547;
 }
 
 /* Tomorrow Green */
 .hljs-string,
-.hljs-value,
-.hljs-inheritance,
-.hljs-header,
-.hljs-addition,
-.ruby .hljs-symbol,
-.xml .hljs-cdata {
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition {
   color: #b9ca4a;
 }
 
-/* Tomorrow Aqua */
-.css .hljs-hexcolor {
-  color: #70c0b1;
-}
-
 /* Tomorrow Blue */
-.hljs-function,
-.python .hljs-decorator,
-.python .hljs-title,
-.ruby .hljs-function .hljs-title,
-.ruby .hljs-title .hljs-keyword,
-.perl .hljs-sub,
-.javascript .hljs-title,
-.coffeescript .hljs-title {
+.hljs-title,
+.hljs-section {
   color: #7aa6da;
 }
 
 /* Tomorrow Purple */
 .hljs-keyword,
-.javascript .hljs-function {
+.hljs-selector-tag {
   color: #c397d8;
 }
 
 .hljs {
   display: block;
+  overflow-x: auto;
   background: black;
   color: #eaeaea;
   padding: 0.5em;
 }
 
-.coffeescript .javascript,
-.javascript .xml,
-.tex .hljs-formula,
-.xml .javascript,
-.xml .vbscript,
-.xml .css,
-.xml .hljs-cdata {
-  opacity: 0.5;
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
 }

--- a/less/sepia.less
+++ b/less/sepia.less
@@ -1,3 +1,5 @@
+/* From https://github.com/isagalaev/highlight.js/blob/9.8.0/src/styles/solarized-light.css */
+
 /*
 
 Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmail.com>
@@ -6,102 +8,79 @@ Orginal Style from ethanschoonover.com/solarized (c) Jeremy Hull <sourdrums@gmai
 
 .hljs {
   display: block;
+  overflow-x: auto;
   padding: 0.5em;
   background: #fdf6e3;
   color: #657b83;
 }
 
 .hljs-comment,
-.hljs-template_comment,
-.diff .hljs-header,
-.hljs-doctype,
-.hljs-pi,
-.lisp .hljs-string,
-.hljs-javadoc {
+.hljs-quote {
   color: #93a1a1;
 }
 
 /* Solarized Green */
 .hljs-keyword,
-.hljs-winutils,
-.method,
-.hljs-addition,
-.css .hljs-tag,
-.hljs-request,
-.hljs-status,
-.nginx .hljs-title {
+.hljs-selector-tag,
+.hljs-addition {
   color: #859900;
 }
 
 /* Solarized Cyan */
 .hljs-number,
-.hljs-command,
 .hljs-string,
-.hljs-tag .hljs-value,
-.hljs-rules .hljs-value,
-.hljs-phpdoc,
-.tex .hljs-formula,
-.hljs-regexp,
-.hljs-hexcolor,
-.hljs-link_url {
+.hljs-meta .hljs-meta-string,
+.hljs-literal,
+.hljs-doctag,
+.hljs-regexp {
   color: #2aa198;
 }
 
 /* Solarized Blue */
 .hljs-title,
-.hljs-localvars,
-.hljs-chunk,
-.hljs-decorator,
-.hljs-built_in,
-.hljs-identifier,
-.vhdl .hljs-literal,
-.hljs-id,
-.css .hljs-function {
+.hljs-section,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class {
   color: #268bd2;
 }
 
 /* Solarized Yellow */
 .hljs-attribute,
+.hljs-attr,
 .hljs-variable,
-.lisp .hljs-body,
-.smalltalk .hljs-number,
-.hljs-constant,
+.hljs-template-variable,
 .hljs-class .hljs-title,
-.hljs-parent,
-.haskell .hljs-type,
-.hljs-link_reference {
+.hljs-type {
   color: #b58900;
 }
 
 /* Solarized Orange */
-.hljs-preprocessor,
-.hljs-preprocessor .hljs-keyword,
-.hljs-pragma,
-.hljs-shebang,
 .hljs-symbol,
-.hljs-symbol .hljs-string,
-.diff .hljs-change,
-.hljs-special,
-.hljs-attr_selector,
+.hljs-bullet,
 .hljs-subst,
-.hljs-cdata,
-.clojure .hljs-title,
-.css .hljs-pseudo,
-.hljs-header {
+.hljs-meta,
+.hljs-meta .hljs-keyword,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-link {
   color: #cb4b16;
 }
 
 /* Solarized Red */
-.hljs-deletion,
-.hljs-important {
+.hljs-built_in,
+.hljs-deletion {
   color: #dc322f;
 }
 
-/* Solarized Violet */
-.hljs-link_label {
-  color: #6c71c4;
+.hljs-formula {
+  background: #eee8d5;
 }
 
-.tex .hljs-formula {
-  background: #eee8d5;
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
 }

--- a/less/white.less
+++ b/less/white.less
@@ -1,92 +1,74 @@
+/* From https://github.com/isagalaev/highlight.js/blob/9.8.0/src/styles/tomorrow.css */
+
 /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
 /* Tomorrow Comment */
 .hljs-comment,
-.hljs-title {
+.hljs-quote {
   color: #8e908c;
 }
 
 /* Tomorrow Red */
 .hljs-variable,
-.hljs-attribute,
+.hljs-template-variable,
 .hljs-tag,
+.hljs-name,
+.hljs-selector-id,
+.hljs-selector-class,
 .hljs-regexp,
-.hljs-deletion,
-.ruby .hljs-constant,
-.xml .hljs-tag .hljs-title,
-.xml .hljs-pi,
-.xml .hljs-doctype,
-.html .hljs-doctype,
-.css .hljs-id,
-.css .hljs-class,
-.css .hljs-pseudo {
+.hljs-deletion {
   color: #c82829;
 }
 
 /* Tomorrow Orange */
 .hljs-number,
-.hljs-preprocessor,
-.hljs-pragma,
 .hljs-built_in,
+.hljs-builtin-name,
 .hljs-literal,
+.hljs-type,
 .hljs-params,
-.hljs-constant {
+.hljs-meta,
+.hljs-link {
   color: #f5871f;
 }
 
 /* Tomorrow Yellow */
-.ruby .hljs-class .hljs-title,
-.css .hljs-rules .hljs-attribute {
+.hljs-attribute {
   color: #eab700;
 }
 
 /* Tomorrow Green */
 .hljs-string,
-.hljs-value,
-.hljs-inheritance,
-.hljs-header,
-.hljs-addition,
-.ruby .hljs-symbol,
-.xml .hljs-cdata {
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition {
   color: #718c00;
 }
 
-/* Tomorrow Aqua */
-.css .hljs-hexcolor {
-  color: #3e999f;
-}
-
 /* Tomorrow Blue */
-.hljs-function,
-.python .hljs-decorator,
-.python .hljs-title,
-.ruby .hljs-function .hljs-title,
-.ruby .hljs-title .hljs-keyword,
-.perl .hljs-sub,
-.javascript .hljs-title,
-.coffeescript .hljs-title {
+.hljs-title,
+.hljs-section {
   color: #4271ae;
 }
 
 /* Tomorrow Purple */
 .hljs-keyword,
-.javascript .hljs-function {
+.hljs-selector-tag {
   color: #8959a8;
 }
 
 .hljs {
   display: block;
+  overflow-x: auto;
   background: white;
   color: #4d4d4c;
   padding: 0.5em;
 }
 
-.coffeescript .javascript,
-.javascript .xml,
-.tex .hljs-formula,
-.xml .javascript,
-.xml .vbscript,
-.xml .css,
-.xml .hljs-cdata {
-  opacity: 0.5;
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
 }

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
         "url": "https://github.com/GitbookIO/plugin-highlight/issues"
     },
     "dependencies": {
-        "highlight.js": "9.2.0"
+        "highlight.js": "9.8.0"
     },
     "devDependencies": {
-        "less": "2.5.1",
-        "mocha":"2.4.5",
-        "gitbook-tester":"1.4.0"
+        "less": "2.7.1",
+        "mocha":"3.2.0",
+        "gitbook-tester":"1.4.3"
     },
     "scripts": {
         "prepublish": "mkdir -p css && lessc ./less/website.less > ./css/website.css; lessc ./less/ebook.less > ./css/ebook.css",


### PR DESCRIPTION
Sync the style with 'highlight.js' 9.8.0.
Update dependencies:

* highlight.js: 9.2.0 => 9.8.0
* less: 2.5.1 => 2.7.1
* mocha: 2.4.5 => 3.1.2
* gitbook-tester: 1.4.0 => 1.4.3

It's necessary to update the dependencies, as less 2.5.1 is broken for
some reason, and output empty css results.

Signed-off-by: Tao Wang <twang2218@gmail.com>