### PR TITLE
make hightlight compatible with faq page

### DIFF
--- a/less/website.less
+++ b/less/website.less
@@ -1,16 +1,22 @@
-.book .book-body .page-wrapper .page-inner section.normal {
+.book .book-body .page-wrapper .page-inner section.normal,
+.faq-page-container .faq-page
+{
     pre, code {
         @import "./white.less";
     }
 }
 
-.book.color-theme-1 .book-body .page-wrapper .page-inner section.normal {
+.book.color-theme-1 .book-body .page-wrapper .page-inner section.normal,
+.color-theme-1 .faq-page-container .faq-page
+{
     pre, code {
         @import "./sepia.less";
     }
 }
 
-.book.color-theme-2 .book-body .page-wrapper .page-inner section.normal {
+.book.color-theme-2 .book-body .page-wrapper .page-inner section.normal,
+.color-theme-2 .faq-page-container .faq-page
+{
     pre, code {
         @import "./night.less";
     }


### PR DESCRIPTION
highlight is not compatible with faq theme page due to css selector.

I made it work together.

Fixes https://github.com/GitbookIO/theme-faq/issues/20